### PR TITLE
Integration with GTest and a really simple example

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-CMAKE_MINIMUM_REQUIRED (VERSION 2.6)
+CMAKE_MINIMUM_REQUIRED (VERSION 3.0)
 
 # Define the version and project name
 SET(CameraModel_Version_Major 0)
@@ -11,10 +11,23 @@ OPTION (ENABLE_TESTS "Build the tests?" OFF)
 # Add the subdirs that are being built
 ADD_SUBDIRECTORY(src)
 
-# TODO: Add the variable, enable GTest or CTest and execute the tests
 # To enable tests pass -DENABLE_TESTS=true to the cmake command
-# TODO: Look at a canonical method for getting GTest added to CMake:  https://crascit.com/2015/07/25/cmake-gtest/
 IF (ENABLE_TESTS)
+	# Download and unpack googletest at configure time
+	CONFIGURE_FILE(tests/CMakeGTEST.txt.in
+	               googletest-download/CMakeLists.txt)
+	EXECUTE_PROCESS(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
+	  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/googletest-download )
+	EXECUTE_PROCESS(COMMAND ${CMAKE_COMMAND} --build .
+	  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/googletest-download )
+
+	# Add googletest directly to our build. This adds
+	# the following targets: gtest, gtest_main, gmock
+	# and gmock_main
+	ADD_SUBDIRECTORY(${CMAKE_BINARY_DIR}/googletest-src
+	                 ${CMAKE_BINARY_DIR}/googletest-build)
+
+	# Now simply link your own targets against gtest, gmock,
+	# etc. as appropriate
 	ADD_SUBDIRECTORY(tests)
-	MESSAGE("Building tests")
 ENDIF(ENABLE_TESTS)

--- a/tests/CMakeGTEST.txt.in
+++ b/tests/CMakeGTEST.txt.in
@@ -1,0 +1,14 @@
+CMAKE_MINIMUM_REQUIRED (VERSION 3.0)
+project(googletest-download NONE)
+
+include(ExternalProject)
+ExternalProject_Add(googletest
+  GIT_REPOSITORY    https://github.com/google/googletest.git
+  GIT_TAG           master
+  SOURCE_DIR        "${CMAKE_BINARY_DIR}/googletest-src"
+  BINARY_DIR        "${CMAKE_BINARY_DIR}/googletest-build"
+  CONFIGURE_COMMAND ""
+  BUILD_COMMAND     ""
+  INSTALL_COMMAND   ""
+  TEST_COMMAND      ""
+)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,3 +1,5 @@
-INCLUDE_DIRECTORIES("${CMAKE_SOURCE_DIR}/include/csm")
-
 ADD_EXECUTABLE(mdisset mdisset.cpp)
+TARGET_INCLUDE_DIRECTORIES(mdisset PUBLIC "${CMAKE_SOURCE_DIR}/include/csm")
+
+ADD_EXECUTABLE(simpletest simpletest.cpp)
+TARGET_LINK_LIBRARIES(simpletest gtest_main)

--- a/tests/mdisset.cpp
+++ b/tests/mdisset.cpp
@@ -12,8 +12,6 @@ int main(int argc, char *argv[]) {
     return 1;
   }
 
-  csm::Isd isd;
-
   //Read the ISD file
   string line;
   string filename(argv[1]);

--- a/tests/simpletest.cpp
+++ b/tests/simpletest.cpp
@@ -1,0 +1,10 @@
+#include <gtest/gtest.h>
+
+TEST(SimpleTest, TrueAssertion) {
+  ASSERT_TRUE(0 == 0);
+}
+
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
- Adds GTest support inside of CMake inline with the cmake docs
- Updated minimum CMake to 3.0 since 2.x is ancient.

This test is super basic and tests nothing...