### PR TITLE
Spice

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,6 @@ include(CheckCXXCompilerFlag)
 # Define the version and project name
 SET(CameraModel_Version_Major 0)
 SET(CameraModel_Version_Minor 1)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 
 PROJECT(CameraModel)
 
@@ -12,7 +11,7 @@ PROJECT(CameraModel)
 SET(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake ${CMAKE_MODULE_PATH})
 
 #Setup to use CPP11
-ADD_COMPILE_OPTIONS(-std=c++11)
+ADD_COMPILE_OPTIONS(-std=c++0x)
 # Setup for external dependencies (either use system or install)
 if( NOT INSTALL_DEPENDENCIES_DIR )
     SET( INSTALL_DEPENDENCIES_DIR ${CMAKE_BINARY_DIR}/INSTALL CACHE STRING "Install directory for dependencies")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,13 @@ else()
 	FIND_PACKAGE(Eigen3 REQUIRED 3.4)
 endif()
 
+# Find Spice
+OPTION (USE_SYSTEM_SPICE "Use system libraries for the NAIFSpice Toolkit" OFF)
+if (${USE_SYSTEM_SPICE} MATCHES "OFF")
+  INCLUDE("${CMAKE_MODULE_PATH}/External-Spice.cmake")
+endif()
+FIND_PACKAGE(Spice)
+
 # Find GDAL
 FIND_PACKAGE(GDAL REQUIRED)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ PROJECT(CameraModel)
 SET(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake ${CMAKE_MODULE_PATH})
 
 #Setup to use CPP11
-ADD_COMPILE_OPTIONS(-std=c++0x)
+ADD_COMPILE_OPTIONS(-std=c++11)
 # Setup for external dependencies (either use system or install)
 if( NOT INSTALL_DEPENDENCIES_DIR )
     SET( INSTALL_DEPENDENCIES_DIR ${CMAKE_BINARY_DIR}/INSTALL CACHE STRING "Install directory for dependencies")

--- a/cmake/External-Spice.cmake
+++ b/cmake/External-Spice.cmake
@@ -1,0 +1,17 @@
+message( "External project - Spice" )
+
+# This is hard coded for linux 64 right now, but should be generalized for all OSes.
+ExternalProject_Add( Spice
+  URL "http://naif.jpl.nasa.gov/pub/naif/toolkit//C/PC_Linux_GCC_64bit/packages/cspice.tar.Z"
+  DOWNLOAD_NAME cspice.tar.gz
+  UPDATE_COMMAND ""
+  CONFIGURE_COMMAND ""
+  BUILD_COMMAND ""
+  INSTALL_COMMAND
+    ${CMAKE_COMMAND} -E copy
+      ${CMAKE_BINARY_DIR}/Spice-prefix/src/Spice/lib/cspice.a
+      ${CMAKE_BINARY_DIR}/Spice-prefix/src/Spice/lib/libcspice.a &&
+    ${CMAKE_COMMAND} -E copy_directory
+      ${CMAKE_BINARY_DIR}/Spice-prefix/src/Spice/
+      ${INSTALL_DEPENDENCIES_DIR}/cspice
+)

--- a/cmake/FindSpice.cmake
+++ b/cmake/FindSpice.cmake
@@ -1,0 +1,91 @@
+
+ #    Copyright (c) 2010-2014, Delft University of Technology
+ #    All rights reserved.
+ #
+ #    Redistribution and use in source and binary forms, with or without modification, are
+ #    permitted provided that the following conditions are met:
+ #      - Redistributions of source code must retain the above copyright notice, this list of
+ #        conditions and the following disclaimer.
+ #      - Redistributions in binary form must reproduce the above copyright notice, this list of
+ #        conditions and the following disclaimer in the documentation and/or other materials
+ #        provided with the distribution.
+ #      - Neither the name of the Delft University of Technology nor the names of its contributors
+ #        may be used to endorse or promote products derived from this software without specific
+ #        prior written permission.
+ #
+ #    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ #    OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ #    MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ #    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ #    EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ #    GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ #    AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ #    NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ #    OF THE POSSIBILITY OF SUCH DAMAGE.
+ #
+ #    Changelog
+ #      YYMMDD    Author            Comment
+ #      12xxxx    B. Tong Minh      File created based on FindEigen3.cmake.
+ #      12xxxx    P. Musegaas
+ #      12xxxx    D. Dirkx          Adapted to detect the SPICE library.
+ #      140127    D. Dirkx          Adapted for custom Spice kernel folder.
+ #      150206    J. Geul           Automatic library find (/w/wo lib prefix)
+ #
+ #
+ #    References
+ #      FindEigen3.cmake.
+ #
+ #    Notes
+ #      This script tries to find SPICE library.
+ #
+ #      Original copyright statements (from FindEigen3.cmake:
+ #          Copyright (c) 2006, 2007 Montel Laurent, <montel@kde.org>
+ #          Copyright (c) 2008, 2009 Gael Guennebaud, <g.gael@free.fr>
+ #          Copyright (c) 2009 Benoit Jacob <jacob.benoit.1@gmail.com>
+ #
+ #      FindEigen3.cmake states that redistribution and use is allowed according to the terms of
+ #      the 2-clause BSD license.
+
+# If the path has not been set previously or manually, try to autodetect the path
+if(NOT SPICE_BASE_PATH)
+    find_path(SPICE_BASE_PATH NAMES SpiceUsr.h
+        PATHS
+            ${INSTALL_DEPENDENCIES_DIR}
+        PATH_SUFFIXES cspice/include
+)
+endif(NOT SPICE_BASE_PATH)
+
+# If the path is still not set, then autodetection went wrong
+if(NOT SPICE_BASE_PATH)
+
+  # Throw a warning and disable SPICE
+  message(WARNING "WARNING: SPICE not found! USE_CSPICE flag has been disabled.")
+  SET(USE_CSPICE false)
+
+else(NOT SPICE_BASE_PATH)
+
+  # Good, path has been set/found, now set important variables and find libraries.
+  set(SPICE_BASE_PATH ${SPICE_BASE_PATH}/..)
+  set(SPICE_INCLUDE_DIR ${SPICE_BASE_PATH}/..)
+  set(SPICE_LIBRARIES_DIR ${SPICE_BASE_PATH}/lib)
+
+  find_library(SPICE_LIBRARIES
+	NAMES libcspice.a libcspice.lib cspice.a cspice.lib
+	PATHS ${SPICE_LIBRARIES_DIR})
+
+  # Force SPICE libraries, to be used when spice and other libraries are simultaneously compiled.
+  if(NOT SPICE_LIBRARIES)
+    set(SPICE_LIBRARIES "cspice")
+  endif( )
+
+  # Let user know which SPICE library was found.
+  message(STATUS "SPICE_LIBRARIES: ${SPICE_LIBRARIES}")
+
+  link_directories(${SPICE_LIBRARIES_DIR})
+
+  include(FindPackageHandleStandardArgs)
+  find_package_handle_standard_args(SPICE DEFAULT_MSG SPICE_INCLUDE_DIR)
+
+  mark_as_advanced(SPICE_INCLUDE_DIR)
+
+endif(NOT SPICE_BASE_PATH)


### PR DESCRIPTION
This PR add SPICE into the build system.  I have reservations about doing this because we are suddenly coupling the spice requirement with our CSM.  I would prefer to see two distinct libraries: (1) the camera models and (2) positional information - where Spice is one methods to get positional information.  

Maybe something akin to:

src
    /apps  #Example uses of the libraries
    /isd  #The ISD library that includes Spice/Eigen/JSON 
    /camera  #The camera library that depends on the CSM
   /transformations #A library of transformation functionality

Thoughts?